### PR TITLE
fix stdin on neovim and reuse markdown hightlight on bito filetype

### DIFF
--- a/plugin/bitoai.vim
+++ b/plugin/bitoai.vim
@@ -63,7 +63,7 @@ function! BitoAiExec(prompt, input)
 
     let l:cmdList = [g:vim_bito_path, '-p', l:templatePath, '-f', l:tempFile]
     if has('nvim')
-        let job = jobstart(l:cmdList, {'on_stdout': 'BiAsyncCallback'})
+        let job = jobstart(l:cmdList, {'on_stdout': 'BiAsyncCallback', 'stdin': 'null'})
     else
         let job = job_start(l:cmdList, {'out_cb': 'BiAsyncCallback', 'in_io': 'null'})
     endif

--- a/plugin/bitoai.vim
+++ b/plugin/bitoai.vim
@@ -1,6 +1,9 @@
 if exists('g:loaded_vim_bito')
     finish
 endif
+if has('nvim')
+    lua vim.treesitter.language.register('markdown', 'bito')
+endif
 let g:loaded_vim_bito = 1
 let g:bito_buffer_name_prefix = get(g:, 'bito_buffer_name_prefix', 'bito_history_')
 let g:vim_bito_plugin_path = fnamemodify(expand('<sfile>:p:h'), ':p')


### PR DESCRIPTION
fix #1 and reuse markdown hightlight on bito filetype

![](https://github.com/zhenyangze/vim-bitoai/assets/25300418/69a1838f-f028-4ddf-b696-38f985d8c3c2)
